### PR TITLE
Доработал чарт для k8s-iae

### DIFF
--- a/.helm/charts/k8s-image-availability-exporter/templates/deployment.yaml
+++ b/.helm/charts/k8s-image-availability-exporter/templates/deployment.yaml
@@ -21,7 +21,19 @@ spec:
     spec:
       containers:
       - name: k8s-image-availability-exporter
-        args: ["--bind-address=:8080"]
+        {{- if .Values.k8sImageAvailabilityExporter.args }}
+        args:
+        {{- range .Values.k8sImageAvailabilityExporter.args }}
+          - {{ . }}
+        {{- end }}
+        {{- end }}
+        {{- if .Values.k8sImageAvailabilityExporter.env }}
+        env:
+        {{- range .Values.k8sImageAvailabilityExporter.env }}
+          - name: {{ .name }}
+            value: {{ .value | quote }}
+        {{- end }}
+        {{- end }}
         ports:
         - containerPort: 8080
           name: http
@@ -37,8 +49,8 @@ spec:
             path: /healthz
             port: http
             scheme: HTTP
+        {{- if .Values.k8sImageAvailabilityExporter.resources }}
         resources:
-        {{ if .Values.k8sImageAvailabilityExporter.resources }}
-{{ .Values.k8sImageAvailabilityExporter.resources | toYaml | indent 10}}
+          {{ .Values.k8sImageAvailabilityExporter.resources | toYaml | indent 10}}
         {{ end }}
       serviceAccountName: {{ template "k8s-image-availability-exporter.fullname" . }}

--- a/.helm/charts/k8s-image-availability-exporter/values.yaml
+++ b/.helm/charts/k8s-image-availability-exporter/values.yaml
@@ -1,10 +1,15 @@
 k8sImageAvailabilityExporter:
   image:
-    repository: flant/k8s-image-availability-exporter
-    tag: v0.1.13
-    pullPolicy: IfNotPresent
+    repository: registry.deckhouse.io/k8s-image-availability-exporter/k8s-image-availability-exporter
+    tag: v0.2.1
+    imagePullPolicy: IfNotPresent
   replicas: 1
   resources: {}
+  args:
+    - --bind-address=:8080
+  env: {}
+    # - name: key
+    #   value: value
 
 serviceMonitor:
   enabled: false


### PR DESCRIPTION
1. Добавил возможность указывать произвольные аргументы запуска
2. Добавил возможность указывать переменные окружения
3. Поправил опечатку из-за которой игнорировалась политика проверки образа
4. Переключил дефолтный образ на актуальные репозиторий и тег
5. Немного улучшил валидность рендеренного YAML